### PR TITLE
add AWS account ID to the S3 lambda:InvokeFunction to improve security

### DIFF
--- a/deployment/auto-check-in-app.template
+++ b/deployment/auto-check-in-app.template
@@ -373,6 +373,7 @@ Resources:
       FunctionName: !GetAtt IndexFaceLambda.Arn
       Principal: s3.amazonaws.com
       SourceArn: !Sub "arn:aws:s3:::${RegistrationBucketNamePrefix}-${AWS::Region}-${AWS::AccountId}"
+      SourceAccount: !Ref 'AWS::AccountId'
 
   AutoCheckinAppLogGroup:
     Type: AWS::Logs::LogGroup


### PR DESCRIPTION
*Description of changes:*
The fix Specifies the owning account in addition to the bucket name to provide the the strictest security.

This avoid the case of someone else creating an S3 bucket with the same name, and then abusing this trust relationship.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
